### PR TITLE
fix scalastyle url

### DIFF
--- a/src/test.md
+++ b/src/test.md
@@ -474,7 +474,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 リグレッションを検出するためにつかわれます。
 その際に、CIの一環として一緒に行われることが多いのがコードスタイルチェックです。
 
-ここでは、[ScalaStyle](http://www.scalastyle.org/sbt.html)を利用します。
+ここでは、[ScalaStyle](https://scalastyle.github.io)を利用します。
 
 使い方は、`project/plugins.sbt` に以下のコードを記述します。
 


### PR DESCRIPTION
https://github.com/scalastyle/scalastyle/issues/345

https://travis-ci.org/dwango/scala_text/builds/568181971#L721

```
  14 passing (878ms)
  1 failing
  1) Check links
       should url return successful response:
     Error: http://www.scalastyle.org/sbt.html: Error: getaddrinfo ENOTFOUND www.scalastyle.org www.scalastyle.org:80
      at test/link.js:299:24
      at _rejected (node_modules/q/q.js:864:24)
      at node_modules/q/q.js:890:30
      at Promise.when (node_modules/q/q.js:1142:31)
      at Promise.promise.promiseDispatch (node_modules/q/q.js:808:41)
      at node_modules/q/q.js:624:44
      at runSingle (node_modules/q/q.js:137:13)
      at flush (node_modules/q/q.js:125:13)
      at process._tickCallback (internal/process/next_tick.js:150:11)
```

