### PR TITLE
dwangoをscalajpに書き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ScalaText
 
-[![Build Status](https://api.travis-ci.org/dwango/scala_text.svg?branch=master)](https://travis-ci.org/dwango/scala_text)
+[![Build Status](https://api.travis-ci.org/scalajp/scala_text.svg?branch=master)](https://travis-ci.org/scalajp/scala_text)
 
 このテキストはドワンゴの新入社員Scala研修のために作成されたものである。
 
@@ -8,9 +8,9 @@
 
 このテキストのコンパイル済み成果物は次の場所から入手できる。
 
-- HTML版：https://dwango.github.io/scala_text/
+- HTML版：https://scalajp.github.io/scala_text/
 - PDF版：https://dwango.github.io/scala_text_pdf/scala_text.pdf
-- EPUB版：https://dwango.github.io/scala_text/scala_text.epub
+- EPUB版：https://scalajp.github.io/scala_text/scala_text.epub
 
 ## 目的
 
@@ -34,7 +34,7 @@ Markdownで記述し、GitBookで静的サイトにしてGitHub Pages上に公�
 以下のコマンドで初期設定を行うことができる。
 
 ```sh
-git clone https://github.com/dwango/scala_text
+git clone https://github.com/scalajp/scala_text
 cd scala_text
 npm install
 ```
@@ -144,14 +144,14 @@ sbt textBuildEpub
 ## フィードバック
 
 ### 誤字・脱字や技術的誤りの指摘・修正
-- [scala_text](https://github.com/dwango/scala_text)のissue欄およびpull requestへ 
+- [scala_text](https://github.com/scalajp/scala_text)のissue欄およびpull requestへ 
   
 ### 誤りとはいえないが改善して欲しい点や加筆して欲しい点に関して
-- [scala_text](https://github.com/dwango/scala_text)のissue欄へ
+- [scala_text](https://github.com/scalajp/scala_text)のissue欄へ
 - 特に１節を超えるレベルの加筆修正については、pull reqeust を送られても、文体の統一や文章の継続したメンテナンスの観点等から、対応するのが難しいのでご了承いただけると助かります。
 
 ### その他全体的な感想や改善要望
-- [専用issue](https://github.com/dwango/scala_text/issues/235)へ
+- [専用issue](https://github.com/scalajp/scala_text/issues/235)へ
 
 ## ライセンス
 

--- a/book.json
+++ b/book.json
@@ -20,7 +20,7 @@
       ]
     },
     "forkmegithub": {
-      "url": "https://github.com/dwango/scala_text",
+      "url": "https://github.com/scalajp/scala_text",
       "color": "darkblue"
     }
   },

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,15 +20,15 @@ echo -e "*class\ntarget" > .gitignore &&
 cp -r ../_book/* ./ &&
 git add . &&
 git commit -a -m "auto commit on travis $TRAVIS_JOB_NUMBER $TRAVIS_COMMIT" &&
-if [[ "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_REPO_SLUG}" == "dwango/scala_text"  ]];
-then git push git@github.com:dwango/scala_text.git gh-pages:gh-pages ; fi
+if [[ "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_REPO_SLUG}" == "scalajp/scala_text"  ]];
+then git push git@github.com:scalajp/scala_text.git gh-pages:gh-pages ; fi
 
 git checkout -qf $TRAVIS_COMMIT
 openssl aes-256-cbc -k "$PREVIEW_KEY" -in preview_key.enc -d -a -out preview.key
 cp preview.key ~/.ssh/
 chmod 600 ~/.ssh/preview.key
 echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/preview.key\n" > ~/.ssh/config
-git clone git@github.com:dwango/scala_text_previews.git
+git clone git@github.com:scalajp/scala_text_previews.git
 cd scala_text_previews
 rm -rf ./${TRAVIS_BRANCH}
 mkdir -p ${TRAVIS_BRANCH}
@@ -38,13 +38,13 @@ git commit -a -m "auto commit on travis $TRAVIS_JOB_NUMBER $TRAVIS_COMMIT $TRAVI
 git push origin gh-pages:gh-pages
 cd ..
 
-if [[ "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_REPO_SLUG}" == "dwango/scala_text" ]]; then
+if [[ "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_EVENT_TYPE}" == "push" && "${TRAVIS_REPO_SLUG}" == "scalajp/scala_text" ]]; then
   git checkout -qf $TRAVIS_COMMIT
   openssl aes-256-cbc -k "$PDF_KEY" -in travis_deploy_pdf_key.enc -d -a -out pdf.key
   cp pdf.key ~/.ssh/
   chmod 600 ~/.ssh/pdf.key
   echo -e "Host github.com\n\tStrictHostKeyChecking no\nIdentityFile ~/.ssh/pdf.key\n" > ~/.ssh/config
-  git clone git@github.com:dwango/scala_text_pdf.git
+  git clone git@github.com:scalajp/scala_text_pdf.git
   cd scala_text_pdf
   git submodule update --init
   cd scala_text

--- a/src/INTRODUCTION.md
+++ b/src/INTRODUCTION.md
@@ -30,9 +30,9 @@
 
 ## フィードバック
 * 誤字・脱字の指摘や修正、および明確な技術的誤りの指摘や修正：
-  * [scala_text](https://github.com/dwango/scala_text)のissue欄およびpull requestへ
+  * [scala_text](https://github.com/scalajp/scala_text)のissue欄およびpull requestへ
 * それ以外の改善要望や感想：
-  * [専用issue](https://github.com/dwango/scala_text/issues/235)へ
+  * [専用issue](https://github.com/scalajp/scala_text/issues/235)へ
 
 よろしくお願いいたします。
 

--- a/src/advanced-trait-di.md
+++ b/src/advanced-trait-di.md
@@ -8,9 +8,9 @@
 今回使われるサンプルプログラムは以下の場所にあります。
 実際に動かしたい場合は個々のディレクトリに入り、sbtを起動してください。
 
-[リファクタリング前のプログラム](https://github.com/dwango/scala_text/tree/master/src/example_projects/trait-example)
+[リファクタリング前のプログラム](https://github.com/scalajp/scala_text/tree/master/src/example_projects/trait-example)
 
-[リファクタリング後のプログラム](https://github.com/dwango/scala_text/tree/master/src/example_projects/trait-refactored-example)
+[リファクタリング後のプログラム](https://github.com/scalajp/scala_text/tree/master/src/example_projects/trait-refactored-example)
 
 ## リファクタリング前のプログラムの紹介
 

--- a/src/exercises.md
+++ b/src/exercises.md
@@ -20,6 +20,6 @@ URL: http://aperiodic.net/phil/scala/s-99/
 
 なお、S99の問題の模範解答として、
 
-https://github.com/dwango/S99
+https://github.com/scalajp/S99
 
 というリポジトリを用意してあります。全ての解答が整備されているわけではありませんが、考えても解答がわからない場合は参考にしても良いでしょう。また、各問題の解答についてのテストケースも書いてあります。

--- a/src/sbt-install.md
+++ b/src/sbt-install.md
@@ -108,6 +108,6 @@ sbtは`sbt --version`もしくは`sbt --launcher-version`とするとversionが�
 
 [^scalac]: ここで言う"手動で"とは、`scalac`コマンドを直接呼び出すという意味です
 
-[^hyphen]: ハイフンは1つではなく2つなので注意。versionの詳細について知りたい場合は、こちらも参照。 https://github.com/dwango/scala_text/issues/122
+[^hyphen]: ハイフンは1つではなく2つなので注意。versionの詳細について知りたい場合は、こちらも参照。 https://github.com/scalajp/scala_text/issues/122
 
 [^latest]: 具体的にはこれを書いている2019年1月時点の最新版である1.2.8。


### PR DESCRIPTION
https://github.com/scalajp/scala_text/issues/505

とりあえず  https://dwango.github.io/scala_text/ などが404でエラーでCI通らない状態なので、簡単に書き換え可能な部分だけ書き換え。移行作業はこれで全てではないが、ひとまず

https://travis-ci.org/scalajp/scala_text/builds/589803097